### PR TITLE
add mysql support

### DIFF
--- a/mattermost-retention.sh
+++ b/mattermost-retention.sh
@@ -8,22 +8,46 @@ DB_PASS=""
 DB_HOST="db"
 RETENTION="0"
 DATA_PATH="/mattermost/data/"
+DB_DRIVE="mysql"
 
 # calculate epoch in milisec
 delete_before=$(date  --date="$RETENTION day ago"  "+%s%3N")
 #delete_before=$(date  "+%s%3N")
 echo $(date  --date="$RETENTION day ago")
-# run psql command do delete posts older than RETENTION var
-export PGPASSWORD=$DB_PASS
 
-# get list of files to be removed
-psql -h "$DB_HOST" -U"$DB_USER" "$DB_NAME" -t -c "select path from fileinfo where createat < $delete_before;" > /tmp/mattermost-paths.list
-psql -h "$DB_HOST" -U"$DB_USER" "$DB_NAME" -t -c "select thumbnailpath from fileinfo where createat < $delete_before;" >> /tmp/mattermost-paths.list
-psql -h "$DB_HOST" -U"$DB_USER" "$DB_NAME" -t -c "select previewpath from fileinfo where createat < $delete_before;" >> /tmp/mattermost-paths.list
+case $DB_DRIVE in
 
-# cleanup db 
-psql -h "$DB_HOST" -U"$DB_USER" "$DB_NAME" -t -c "delete from posts where createat < $delete_before;"
-psql -h "$DB_HOST" -U"$DB_USER" "$DB_NAME" -t -c "delete from fileinfo where createat < $delete_before;"
+  postgres)
+        echo "Using postgres database."
+        export PGPASSWORD=$DB_PASS
+
+        # get list of files to be removed
+        psql -h "$DB_HOST" -U"$DB_USER" "$DB_NAME" -t -c "select path from fileinfo where createat < $delete_before;" > /tmp/mattermost-paths.list
+        psql -h "$DB_HOST" -U"$DB_USER" "$DB_NAME" -t -c "select thumbnailpath from fileinfo where createat < $delete_before;" >> /tmp/mattermost-paths.list
+        psql -h "$DB_HOST" -U"$DB_USER" "$DB_NAME" -t -c "select previewpath from fileinfo where createat < $delete_before;" >> /tmp/mattermost-paths.list
+
+        # cleanup db 
+        psql -h "$DB_HOST" -U"$DB_USER" "$DB_NAME" -t -c "delete from posts where createat < $delete_before;"
+        psql -h "$DB_HOST" -U"$DB_USER" "$DB_NAME" -t -c "delete from fileinfo where createat < $delete_before;"
+    ;;
+
+  mysql)
+        echo "Using mysql database."
+
+        # get list of files to be removed
+        mysql --password=$DB_PASS --user=$DB_USER --host=$DB_HOST --database=$DB_NAME --execute="select path from FileInfo where createat < $delete_before;" > /tmp/mattermost-paths.list
+        mysql --password=$DB_PASS --user=$DB_USER --host=$DB_HOST --database=$DB_NAME --execute="select thumbnailpath from FileInfo where createat < $delete_before;" >> /tmp/mattermost-paths.list
+        mysql --password=$DB_PASS --user=$DB_USER --host=$DB_HOST --database=$DB_NAME --execute="select previewpath from FileInfo where createat < $delete_before;" >> /tmp/mattermost-paths.list
+
+        # cleanup db 
+        mysql --password=$DB_PASS --user=$DB_USER --host=$DB_HOST --database=$DB_NAME --execute="delete from Posts where createat < $delete_before;"
+        mysql --password=$DB_PASS --user=$DB_USER --host=$DB_HOST --database=$DB_NAME --execute="delete from FileInfo where createat < $delete_before;"
+    ;;
+  *)
+        echo "Unknown DB_DRIVE option. Currently only MySQL and postgresql are available."
+        exit 1
+    ;;
+esac
 
 # delete files
 while read -r fp; do
@@ -39,4 +63,3 @@ rm /tmp/mattermost-paths.list
 #cleanup empty data dirs
 find $DATA_PATH -type d -empty -delete
 exit 0
-


### PR DESCRIPTION
Hi!

After see that this tool is the exact thing that my team needed to cleanup a MM installation I created a little contribution to work with Mysql installations.

Basically it add a switch to choose between postgres/mysql and translate the query (CamelCase conventions) 
keeping the same functioning.

We tested on a base with 55,000 attachments to be deleted without problems.