### PR TITLE
Refactor file deletion process for safety and security

### DIFF
--- a/mattermost-retention.sh
+++ b/mattermost-retention.sh
@@ -83,16 +83,17 @@ esac
 
 
 ###
-# delete files
+# delete files safely
 ###
-for fp in `cat /tmp/mattermost-paths.list`
-do
-        if [ -n "$fp" ]; then
-                echo "$DATA_PATH""$fp"
-                $MM_DOCKER_CMD shred -u "$DATA_PATH""$fp"
+while IFS= read -r fp; do
+    if [ -n "$fp" ]; then
+        full_path="${DATA_PATH}${fp}"
+        if [ -f "$full_path" ]; then
+            echo "Shredding: $full_path"
+            $MM_DOCKER_CMD shred -u -n 3 "$full_path" # 3 passes is plenty for modern drives
         fi
-done
-
+    fi
+done < /tmp/mattermost-paths.list
 
 ###
 # cleanup after script execution


### PR DESCRIPTION
Refactor file deletion to use safer reading method and add checks for file existence. Update shredding command to use multiple passes for better security.

Reason: Mattermost paths may, probably, have spaces or special characters. To prevent the `cat` loop from breaking, using a `while read` loop instead, is safer for a production environment.